### PR TITLE
Update Go docs link title

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,7 +10,7 @@ The Pulumi Statuscake provider is available as a package in all Pulumi languages
 
 - JavaScript/TypeScript: [`@pulumiserve/statuscake`](https://www.npmjs.com/package/@pulumiverse/statuscake)
 - Python: [`pulumiverse_statuscake`](https://pypi.org/project/pulumiverse-statuscake/)
-- Go: [`github.com/pulumiverse/pulumi-statuscake/sdk/go/statuscake`](https://pkg.go.dev/github.com/pulumiverse/pulumi-statuscake/sdk)
+- Go: [`github.com/pulumiverse/pulumi-statuscake/sdk`](https://pkg.go.dev/github.com/pulumiverse/pulumi-statuscake/sdk)
 - .NET: [`Pulumiverse.Statuscake`](https://www.nuget.org/packages/Pulumiverse.Statuscake)
 
 ## Setup


### PR DESCRIPTION
The link is already ok (had to request Go docs indexing).
Pushed tag v1.0.2.
Fixes #6 